### PR TITLE
Fee fixes implemented

### DIFF
--- a/app/Network.ts
+++ b/app/Network.ts
@@ -264,9 +264,10 @@ export class Network {
     return agents;
   }
 
-  private initProvider() {
+  private async initProvider() {
     this.provider = new ethers.providers.WebSocketProvider(this.rpc);
     this.fixProvider(this.provider);
+    // instance.fixProvider(instance.contractWrapperFactory.getDefaultProvider());
     this.contractWrapperFactory = new EthersContractWrapperFactory([this.rpc], this.networkConfig.ws_timeout);
     this.fixProvider(this.contractWrapperFactory.getDefaultProvider());
     this.multicall = this.contractWrapperFactory.build(this.multicall2Address, getMulticall2Abi());
@@ -338,7 +339,7 @@ export class Network {
       return;
     }
 
-    this.initProvider();
+    await this.initProvider();
 
     try {
       const latestBlock = await this.queryLatestBlock();
@@ -672,5 +673,8 @@ export class Network {
   ): Promise<LensGetJobBytes32AndNextBlockSlasherIdResponse> {
     const res = await this.externalLens.ethCall('getJobBytes32AndNextBlockSlasherId', [agent, jobKey]);
     return { binJob: res.binJob, nextBlockSlasherId: res.nextBlockSlasherId.toNumber() };
+  }
+  public async getFeeData() {
+    return this.provider.getFeeData();
   }
 }

--- a/app/Utils.ts
+++ b/app/Utils.ts
@@ -66,7 +66,8 @@ export function prepareTx(tx: UnsignedTransaction, isEstimate = false) {
   const resTx = {
     ...tx,
     value: bigintToHex(tx.value),
-    gasLimit: bigintToHex(isEstimate ? tx.gasLimit : 5_000_000n),
+    gasLimit: bigintToHex(tx.gasLimit),
+    //gasLimit: bigintToHex(isEstimate ? tx.gasLimit : 5_000_000n),
     gasPrice: bigintToHex(tx.gasPrice),
     maxPriorityFeePerGas: bigintToHex(tx.maxPriorityFeePerGas),
     maxFeePerGas: bigintToHex(tx.maxFeePerGas),

--- a/app/executors/FlashbotsExecutor.ts
+++ b/app/executors/FlashbotsExecutor.ts
@@ -61,14 +61,14 @@ export class FlashbotsExecutor extends AbstractExecutor implements Executor {
     const { tx } = envelope;
     let gasLimitEstimation;
     try {
-      gasLimitEstimation = await this.genericProvider.estimateGas(prepareTx(tx));
+      gasLimitEstimation = await this.network.getProvider().estimateGas(prepareTx(tx));
     } catch (e) {
       // TODO (DANGER): hard limit
       tx.gasLimit = 700_000n;
-      tx.nonce = await this.genericProvider.getTransactionCount(this.workerSigner.address);
+      tx.nonce = await this.network.getProvider().getTransactionCount(this.workerSigner.address);
       let txSimulation;
       try {
-        txSimulation = await this.genericProvider.call(prepareTx(tx));
+        txSimulation = await this.network.getProvider().call(prepareTx(tx));
         printSolidityCustomError(
           this.clog.bind(this),
           this.agentContract.decodeError.bind(this.agentContract),
@@ -82,7 +82,7 @@ export class FlashbotsExecutor extends AbstractExecutor implements Executor {
       return;
     }
 
-    tx.nonce = await this.genericProvider.getTransactionCount(this.workerSigner.address);
+    tx.nonce = await this.network.getProvider().getTransactionCount(this.workerSigner.address);
     tx.gasLimit = gasLimitEstimation.mul(15).div(10);
     this.clog('debug', `Signing tx with calldata=${tx.data} ...`);
     const signedBundle = await this.fbProvider.signBundle([
@@ -95,7 +95,7 @@ export class FlashbotsExecutor extends AbstractExecutor implements Executor {
 
     // eslint-disable-next-line no-constant-condition
     while (true) {
-      const targetBlock = (await this.genericProvider.getBlockNumber()) + 1;
+      const targetBlock = (await this.network.getProvider().getBlockNumber()) + 1;
       const simulation = await this.fbProvider.simulate(signedBundle, targetBlock);
       this.clog('debug', `Tx ${txHash}: The tx target block is ${targetBlock}...`);
       if ('error' in simulation) {
@@ -108,9 +108,9 @@ export class FlashbotsExecutor extends AbstractExecutor implements Executor {
         return;
       } else if (simulation.firstRevert !== undefined) {
         // TODO: prettify data for logs
-        console.log({ simulation });
-        console.log({ results: simulation.results[0] });
-        console.log('parsed reason', fbReasonStringToHexString(simulation.firstRevert['revert']));
+        // console.log({ simulation });
+        // console.log({ results: simulation.results[0] });
+        // console.log('parsed reason', fbReasonStringToHexString(simulation.firstRevert['revert']));
         this.clog(
           'debug',
           `Tx ${txHash}: Ignoring the tx due to the Flashbots simulation revert: ${JSON.stringify(


### PR DESCRIPTION
This PR corresponds to an overhaul of the fee computation motivated by horrendous overestimates on mainnet and sometimes on arbi. 

The overestimates were caused by the code using the last block's base fee, which could yield an overestimate if the latest block had a lot of transactions therein. 
- The method of estimating the initial gas costs is changed to the base RPC method using `getProvider().getFeeData()`